### PR TITLE
Resolve Issue #12: Add a Lambda Trigger to storage

### DIFF
--- a/content/60_managing_photos/30_adding_storage.md
+++ b/content/60_managing_photos/30_adding_storage.md
@@ -16,7 +16,7 @@ First, we'll use the Amplify CLI to enable storage for our app. This will create
 
 3. **Enter values or accept defaults** for the resource category and bucket name
 
-4. **Chose Auth and guest users** when asked who should have access. Configure it so that **authenticated users** have access with **create/update, read, and delete access** (use the spacebar to toggle on/off, the arrow keys to move, and Enter to continue) and **guests** have **read permission**. 
+4. **Chose Auth and guest users** when asked who should have access. Configure it so that **authenticated users** have access with **create/update, read, and delete access** (use the spacebar to toggle on/off, the arrow keys to move, and Enter to continue) and **guests** have **read permission**. When prompted about a Lambda Trigger, **select 'No'**.
 
     Here is sample output with responses:
 
@@ -48,6 +48,9 @@ First, we'll use the Amplify CLI to enable storage for our app. This will create
     ◯ create/update
     ◉ read
     ◯ delete
+    
+    
+    ? Do you want to add a Lambda Trigger for your S3 Bucket? No
     ```
 
 Now we'll have Amplify modify our cloud environment, provisioning the storage resources we just added.

--- a/content/70_generating_thumbnails/20_connecting_the_lambda_to_the_bucket.md
+++ b/content/70_generating_thumbnails/20_connecting_the_lambda_to_the_bucket.md
@@ -711,10 +711,19 @@ After you paste the new template shown above, find the text **REPLACE_WITH_USERF
 You can find this value in **photo-albums/src/aws-exports.js** under the **aws_user_files_s3_bucket** key.
 {{% /notice %}}
 
+3. **From the photo-albums directory, run** `amplify update storage`.
 
-3. **From the photo-albums directory, run:** `amplify push` to update our storage configuration. 
+4. **Press Enter** until you reach the prompt about a Lambda Trigger.
 
-4. Wait for the update to complete. This step usually only takes a minute or two.
+5. When prompted, "Do you want to add a Lambda Trigger for your S3 Bucket?", **select 'Yes'**.
+
+6. **Press Enter** to "Choose an existing function from the project".
+
+7. **Press Enter** to select 'workshopphotoprocessor'.
+
+8. **Run** `amplify push` to update our storage configuration. 
+
+9. Wait for the update to complete. This step usually only takes a minute or two.
 
 ### What we changed in amplify/.../s3-cloudformation-template.json
 - Added a *InvokePhotoProcessorLambda* resource, giving the S3Bucket permission to invoke the PhotoProcessor lambda function.


### PR DESCRIPTION
*Issue #, if available:* 12

*Description of changes:*

Eliminate the "Parameters: [triggerFunction] do not exist in the template" error in "Generating Thumbnails":
- Add instructions for the Lambda trigger prompt in `amplify add storage`
- After creating the Lambda function, add it as a trigger with `amplify update storage`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
