### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/content/70_generating_thumbnails/10_creating_a_photo_processor_lambda.md
+++ b/content/70_generating_thumbnails/10_creating_a_photo_processor_lambda.md
@@ -228,7 +228,7 @@ exports.handler = async (event, context, callback) => {
 						"Arn"
 					]
 				},
-				"Runtime": "nodejs8.10",
+				"Runtime": "nodejs10.x",
 				"Timeout": "25"
 			}
 		},


### PR DESCRIPTION
because nodejs8.10 is no longer a supported runtime

Resolves #25 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
